### PR TITLE
High resolution sickness

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ title: Homepage of Tobias Pfeiffer (PragTob)
     <img id="profile-picture" class="img-rounded" src="/images/profile_cropped.png" alt="Profile Picture">
   </div>
   <div id="short-description" class="col-xs-12 col-sm-6 col-md-6 col-md-offset-2 col-lg-6 col-lg-offset-2">
-    <h1>Tobias Pfeiffer<img src="/images/current_status.png" class='my-status'></h1>
+    <h1>Tobias Pfeiffer<img src="http://img.shields.io/:status-SICK-FF0000.svg" class='my-status'></h1>
     <ul class="fa-ul">
       <li><i class="fa-li fa fa-user" title="nick"></i>PragTob</li>
       <li><a href="mailto:pragtob@gmail.com"><i class="fa fa-li fa-envelope" title="Email"></i> pragtob@gmail.com</a></li>


### PR DESCRIPTION
You sick state is improperly displayed on high resolution displays. To see it in all glory, you could replace it by a nice shield from shields.io.

![Sick](http://img.shields.io/:status-SICK-FF0000.svg)
